### PR TITLE
feat: implement missing options, hook events, and message fields

### DIFF
--- a/claude/hooks.go
+++ b/claude/hooks.go
@@ -8,9 +8,13 @@ type HookEvent string
 const (
 	HookEventPreToolUse       HookEvent = "PreToolUse"
 	HookEventPostToolUse      HookEvent = "PostToolUse"
+	// HookEventPostToolUseFailure fires after a tool call fails.
+	HookEventPostToolUseFailure HookEvent = "PostToolUseFailure"
 	HookEventNotification     HookEvent = "Notification"
 	HookEventStop             HookEvent = "Stop"
 	HookEventSubagentStop     HookEvent = "SubagentStop"
+	// HookEventSubagentStart fires when a sub-agent is started.
+	HookEventSubagentStart    HookEvent = "SubagentStart"
 	HookEventPreCompact       HookEvent = "PreCompact"
 	HookEventUserPromptSubmit HookEvent = "UserPromptSubmit"
 	HookEventStart            HookEvent = "Start"
@@ -19,6 +23,8 @@ const (
 	HookEventPreEdit          HookEvent = "PreEdit"
 	HookEventPostEdit         HookEvent = "PostEdit"
 	HookEventSetup            HookEvent = "Setup"
+	// HookEventPermissionRequest fires when Claude requests permission to use a tool.
+	HookEventPermissionRequest HookEvent = "PermissionRequest"
 )
 
 // HookOutput is the return value of a HookFunc. All fields are optional.

--- a/claude/messages.go
+++ b/claude/messages.go
@@ -136,6 +136,11 @@ type Result struct {
 	UUID          string      `json:"uuid"`
 	// Populated when IsError is true.
 	Errors []string `json:"errors,omitempty"`
+	// StructuredOutput holds parsed structured output when an OutputFormat
+	// with type "json" or "json_schema" was requested.
+	StructuredOutput any `json:"structured_output,omitempty"`
+	// PermissionDenials lists any tool calls that were denied during the run.
+	PermissionDenials []string `json:"permission_denials,omitempty"`
 }
 
 // ─── System message ────────────────────────────────────────────────────────────
@@ -163,6 +168,13 @@ type SystemMessage struct {
 	PermissionMode    string   `json:"permissionMode,omitempty"`
 	ClaudeCodeVersion string   `json:"claude_code_version,omitempty"`
 	APIKeySource      string   `json:"apiKeySource,omitempty"`
+
+	// Additional init fields populated by newer CLI versions.
+	Agents        []string `json:"agents,omitempty"`
+	Betas         []string `json:"betas,omitempty"`
+	Skills        []string `json:"skills,omitempty"`
+	Plugins       []string `json:"plugins,omitempty"`
+	SlashCommands []string `json:"slash_commands,omitempty"`
 }
 
 // ─── Top-level Event ──────────────────────────────────────────────────────────

--- a/claude/options.go
+++ b/claude/options.go
@@ -26,6 +26,8 @@ const (
 	EffortLow    EffortLevel = "low"
 	EffortMedium EffortLevel = "medium"
 	EffortHigh   EffortLevel = "high"
+	// EffortMax requests the highest possible reasoning effort.
+	EffortMax EffortLevel = "max"
 )
 
 // PermissionMode controls how Claude handles tool permission requests.
@@ -35,6 +37,12 @@ const (
 	PermissionModeDefault           PermissionMode = "default"
 	PermissionModeAcceptEdits       PermissionMode = "acceptEdits"
 	PermissionModeBypassPermissions PermissionMode = "bypassPermissions"
+	// PermissionModePlan enables planning mode where the agent plans actions
+	// but does not execute tools that modify state.
+	PermissionModePlan PermissionMode = "plan"
+	// PermissionModeDontAsk silently denies any tool call that is not
+	// already pre-approved, without prompting the user.
+	PermissionModeDontAsk PermissionMode = "dontAsk"
 )
 
 // ─── Permission types ─────────────────────────────────────────────────────────
@@ -194,6 +202,34 @@ const (
 	// SettingSourceLocal loads .claude/settings.local.json (gitignored local overrides).
 	SettingSourceLocal SettingSource = "local"
 )
+
+// ─── System prompt preset ─────────────────────────────────────────────────────
+
+// SystemPromptPreset configures a preset system prompt instead of a plain string.
+// Set Type to "preset" and Preset to "claude_code" to use the built-in Claude
+// Code system prompt. Append is optional extra text appended to the preset.
+// Use WithSystemPromptPreset to set this; it takes precedence over WithSystemPrompt.
+type SystemPromptPreset struct {
+	// Type must be "preset".
+	Type string `json:"type"`
+	// Preset names the preset to use (e.g. "claude_code").
+	Preset string `json:"preset"`
+	// Append is optional extra text appended after the preset system prompt.
+	Append string `json:"append,omitempty"`
+}
+
+// ─── Tools preset ─────────────────────────────────────────────────────────────
+
+// ToolsPreset configures the base tool set via a named preset instead of an
+// explicit list. Set Type to "preset" and Preset to "claude_code" to use the
+// default Claude Code tool set.
+// Use WithToolsPreset to set this; it is passed as --tools to the subprocess.
+type ToolsPreset struct {
+	// Type must be "preset".
+	Type string `json:"type"`
+	// Preset names the preset (e.g. "claude_code").
+	Preset string `json:"preset"`
+}
 
 // ─── Agent types ──────────────────────────────────────────────────────────────
 
@@ -385,6 +421,32 @@ type Options struct {
 	// When empty, no filesystem settings are loaded (SDK isolation mode).
 	SettingSources []SettingSource
 
+	// AdditionalDirectories lists extra directories passed to the subprocess
+	// via --add-dir. These directories are added to the allowed directory set
+	// in addition to the CWD.
+	AdditionalDirectories []string
+
+	// ExtraArgs holds arbitrary extra CLI flags passed verbatim to the claude
+	// subprocess. Keys are flag names (e.g. "--some-flag"); values are the
+	// argument values (use empty string "" for boolean flags with no value).
+	// This provides forward-compatibility for flags not yet modelled in Options.
+	ExtraArgs map[string]string
+
+	// SystemPromptPreset configures a named preset system prompt.
+	// When set it takes precedence over SystemPrompt.
+	// Use WithSystemPromptPreset; leave nil to use SystemPrompt instead.
+	SystemPromptPreset *SystemPromptPreset
+
+	// ToolsPreset configures the base tool set via a named preset.
+	// Passed to the subprocess as --tools with a JSON payload.
+	// When nil the AllowedTools list (--allowedTools) is used as usual.
+	ToolsPreset *ToolsPreset
+
+	// Stderr is an optional callback invoked with each line written to the
+	// claude subprocess's stderr. Useful for capturing diagnostic output.
+	// When nil, stderr is silently captured and included in errors on failure.
+	Stderr func(line string)
+
 	// Env contains additional environment variables merged into the subprocess env.
 	Env map[string]string
 
@@ -558,6 +620,45 @@ func WithSettings(s string) Option {
 	return func(o *Options) { o.Settings = s }
 }
 
+// WithAdditionalDirectories adds directories to the subprocess's allowed directory
+// set via --add-dir. Each call appends to the existing list.
+func WithAdditionalDirectories(dirs ...string) Option {
+	return func(o *Options) { o.AdditionalDirectories = append(o.AdditionalDirectories, dirs...) }
+}
+
+// WithExtraArgs sets arbitrary extra CLI flags passed verbatim to the claude
+// subprocess. Keys are flag names (e.g. "--some-flag"); use an empty string
+// value for boolean flags that take no argument.
+// Multiple calls merge into the same map; later calls overwrite duplicate keys.
+func WithExtraArgs(args map[string]string) Option {
+	return func(o *Options) {
+		if o.ExtraArgs == nil {
+			o.ExtraArgs = make(map[string]string)
+		}
+		for k, v := range args {
+			o.ExtraArgs[k] = v
+		}
+	}
+}
+
+// WithSystemPromptPreset sets a named preset system prompt.
+// Takes precedence over WithSystemPrompt when both are set.
+func WithSystemPromptPreset(p *SystemPromptPreset) Option {
+	return func(o *Options) { o.SystemPromptPreset = p }
+}
+
+// WithToolsPreset sets the base tool set via a named preset, passed to the
+// subprocess as --tools with a JSON payload. When set, AllowedTools is ignored.
+func WithToolsPreset(p *ToolsPreset) Option {
+	return func(o *Options) { o.ToolsPreset = p }
+}
+
+// WithStderr sets a callback invoked for each line written to the claude
+// subprocess's stderr. Useful for capturing diagnostic/debug output.
+func WithStderr(fn func(line string)) Option {
+	return func(o *Options) { o.Stderr = fn }
+}
+
 // WithSettingSources controls which settings files are loaded by the subprocess.
 // Pass one or more of SettingSourceUser, SettingSourceProject, SettingSourceLocal.
 // When not called, no filesystem settings are loaded (SDK isolation mode).
@@ -697,6 +798,20 @@ func (o *Options) buildArgs() []string {
 		}
 	}
 
+	// AdditionalDirectories: each directory gets its own --add-dir flag.
+	for _, dir := range o.AdditionalDirectories {
+		if dir != "" {
+			args = append(args, "--add-dir", dir)
+		}
+	}
+
+	// ToolsPreset: passed as --tools with a JSON payload.
+	if o.ToolsPreset != nil {
+		if b, err := json.Marshal(o.ToolsPreset); err == nil {
+			args = append(args, "--tools", string(b))
+		}
+	}
+
 	// Settings: file path or inline JSON passed to --settings.
 	// When set, --setting-sources is skipped (Settings takes precedence).
 	if o.Settings != "" {
@@ -717,6 +832,20 @@ func (o *Options) buildArgs() []string {
 		mcpCfg := map[string]any{"mcpServers": o.McpServers}
 		if b, err := json.Marshal(mcpCfg); err == nil {
 			args = append(args, "--mcp-config", string(b))
+		}
+	}
+
+	// ExtraArgs: arbitrary extra flags for forward-compatibility.
+	// Boolean flags (empty value) are appended as a single element; flags with
+	// a value are appended as two elements (flag, value).
+	for flag, val := range o.ExtraArgs {
+		if flag == "" {
+			continue
+		}
+		if val == "" {
+			args = append(args, flag)
+		} else {
+			args = append(args, flag, val)
 		}
 	}
 

--- a/claude/version.go
+++ b/claude/version.go
@@ -1,0 +1,6 @@
+package claude
+
+// SDKVersion is the current version of the claude-agent-sdk-go module.
+// It is reported to the claude subprocess via the CLAUDE_AGENT_SDK_VERSION
+// environment variable for Anthropic telemetry.
+const SDKVersion = "0.2.2"


### PR DESCRIPTION
## Summary

Closes parity gaps between the Go SDK and the official Python/TypeScript SDKs.

### Options (`options.go`)
- **`PermissionModePlan`** and **`PermissionModeDontAsk`** — two permission mode constants missing from the Go SDK
- **`EffortMax`** — adds the `"max"` effort level (already supported by TypeScript SDK)
- **`SystemPromptPreset`** struct + **`WithSystemPromptPreset()`** — named preset system prompts (e.g. `"claude_code"`); takes precedence over plain `SystemPrompt` in the initialize message
- **`ToolsPreset`** struct + **`WithToolsPreset()`** — named preset for the base tool set; passed to the subprocess as `--tools <JSON>`
- **`AdditionalDirectories`** + **`WithAdditionalDirectories()`** — passes `--add-dir` flags to the subprocess (multi-repo setups)
- **`ExtraArgs`** + **`WithExtraArgs()`** — arbitrary extra CLI flags for forward-compatibility
- **`Stderr`** callback + **`WithStderr()`** — streams each subprocess stderr line to a user-supplied callback

### Hook events (`hooks.go`)
- **`HookEventPostToolUseFailure`** — fires after a tool call fails
- **`HookEventSubagentStart`** — fires when a sub-agent starts
- **`HookEventPermissionRequest`** — fires when Claude requests permission to use a tool

### Message types (`messages.go`)
- **`Result.StructuredOutput`** — holds parsed structured output when a JSON output format is requested
- **`Result.PermissionDenials`** — lists tool calls denied during the run
- **`SystemMessage.Agents/Betas/Skills/Plugins/SlashCommands`** — additional init fields populated by newer CLI versions

### Process (`process.go`, `version.go`)
- **`stderrLineWriter`** — line-buffered `io.Writer` that dispatches to `opts.Stderr`
- **`CLAUDE_AGENT_SDK_VERSION`** env var — set on the subprocess for Anthropic telemetry
- **`SystemPromptPreset`** forwarded in the `initialize` message when set
- **`SDKVersion`** constant (`"0.2.2"`) in new `version.go`

## Test plan
- [ ] `go build ./...` passes (verified)
- [ ] `go vet ./...` passes (verified)
- [ ] Review new `With*` option functions for correct behaviour
- [ ] Smoke-test `WithAdditionalDirectories`, `WithExtraArgs`, `WithStderr` manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)