### PR TITLE
docs: add gap analysis regeneration instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,15 @@ The SDK does not call the Claude API directly — it spawns the `claude` CLI as 
 - `mcp.go` / `tool.go` — in-process MCP servers via `modelcontextprotocol/go-sdk`: `StartInProcessMCPServer` (HTTP), `SelfAsStdioMCPServer`/`ServeStdioMCP` (stdio), and the `NewTool`/`WithTools` convenience layer for defining tools as plain Go functions.
 - `errors.go` — `CLINotFoundError`, `ProcessError`, `CLIJSONDecodeError`. Process failures without a result message are surfaced as synthetic `TypeSystem` error events, which `Run()` converts to Go errors.
 
+## Gap analysis
+
+`GAP_ANALYSIS.md` compares this SDK's feature surface against the official SDKs. To regenerate it (do all of this every time):
+
+1. Ensure the official SDKs are checked out as sibling directories of this repo (`../claude-agent-sdk-typescript`, `../claude-agent-sdk-python`); clone them from `https://github.com/anthropics/claude-agent-sdk-typescript` and `https://github.com/anthropics/claude-agent-sdk-python` if missing.
+2. In each, fetch and pull the latest default branch, and identify the latest release tag (`git tag --sort=-v:refname | head -1` or `gh release view`). Analyze against both the branch tip and the latest release, noting features that are on the tip but not yet released.
+3. Compare their public API surface (options, message/event types, stream/session/control methods, hooks, MCP/tool helpers, permission handling) against the `claude/` package, in both directions.
+4. Rewrite `GAP_ANALYSIS.md` keeping its existing structure: `> Generated:` date line, legend (✅ / 🚧 / ❌), and priority-grouped feature tables (missing here but present in both official SDKs = high priority, in one = medium) with TypeScript / Python / Go columns per feature. Record the SDK versions/tags compared.
+
 ## Conventions
 
 - Every PR must be linked to a GitHub issue (see CONTRIBUTING.md); reference it with `Fixes #N`.


### PR DESCRIPTION
## Summary
Follow-up to #11. Adds a "Gap analysis" section to CLAUDE.md describing how to regenerate `GAP_ANALYSIS.md`:

- Clone the official TypeScript and Python SDKs as sibling directories if not already present
- Pull their latest default branch and identify the latest release tag; compare against both
- Compare the public API surface in both directions against the `claude/` package
- Rewrite `GAP_ANALYSIS.md` keeping its existing structure, recording the versions compared